### PR TITLE
Manifest or ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           pkg1 = PackageSpec(url = "https://github.com/paraynaud/CalculusTreeTools.jl.git")
           pkg_list = [pkg1]
           Pkg.add(pkg_list)
-        shell: julia --project=docs --color=yes {0}
+        shell: julia --project=@. --color=yes {0}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,7 @@ jobs:
         run: |
           using Pkg
           pkg1 = PackageSpec(url = "https://github.com/paraynaud/CalculusTreeTools.jl.git")
-          pkg2 = PackageSpec(url = "https://github.com/paraynaud/PartiallySeparableNLPModels.jl.git")
-          pkg_list = [pkg1, pkg2]
+          pkg_list = [pkg1]
           Pkg.add(pkg_list)
         shell: julia --project=docs --color=yes {0}
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-CalculusTreeTools = "995bfbc1-c62b-4971-a5e3-ef0aad32e8da"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CalculusTreeTools = "995bfbc1-c62b-4971-a5e3-ef0aad32e8da"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,5 @@
 [deps]
-CalculusTreeTools = "995bfbc1-c62b-4971-a5e3-ef0aad32e8da"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-PartiallySeparableNLPModels = "7f79d04d-aed5-44bf-a878-92b5ccf934e0"
 
 [compat]
 Documenter = "~0.25"

--- a/src/PartiallySeparableStructure.jl
+++ b/src/PartiallySeparableStructure.jl
@@ -942,10 +942,6 @@ Previous deduct_partially_separable_structure
 #
 #     return SPS{T, type}(structure, different_calculus_tree, index_element_tree, related_vars, x, x_views, v, v_views, length_vec[], n, compiled_gradients)
 # end
-
-
-
-
 # function _deduct_partially_separable_structure(expr_tree :: CalculusTreeTools.complete_expr_tree, n :: Int, type=Float64 :: DataType)
 #     work_expr_tree = copy(expr_tree)
 #     CalculusTreeTools.cast_type_of_constant(work_expr_tree, type)


### PR DESCRIPTION
@dpo 
The installation of unregistered dependencies in ci.yml is not working.
It works well for Documentation.yml.

We have to choose wether we keep the Manifest.toml until the packages are registered or improve somehow the ci.yml.
